### PR TITLE
Improve AutoML Requirements

### DIFF
--- a/adapters/AutoCVE/requirements.txt
+++ b/adapters/AutoCVE/requirements.txt
@@ -1,5 +1,5 @@
 grpcio
-protobuf 
+protobuf==3.17.3
 dill
 jinja2
 git+https://github.com/celiolarcher/AUTOCVE@e87985d#egg=autocve

--- a/adapters/AutoGluon/requirements.txt
+++ b/adapters/AutoGluon/requirements.txt
@@ -1,4 +1,5 @@
-autogluon
+autogluon.tabular
 grpcio
 dill
 jinja2
+protobuf==3.17.3

--- a/adapters/AutoPytorch/requirements.txt
+++ b/adapters/AutoPytorch/requirements.txt
@@ -1,4 +1,4 @@
 autoPyTorch
 grpcio
-protobuf
+protobuf==3.17.3
 dill

--- a/adapters/AutoSklearn/requirements.txt
+++ b/adapters/AutoSklearn/requirements.txt
@@ -1,5 +1,5 @@
 auto-sklearn
 grpcio
-protobuf
+protobuf==3.17.3
 dill
 jinja2

--- a/adapters/MLJAR/requirements.txt
+++ b/adapters/MLJAR/requirements.txt
@@ -1,5 +1,5 @@
 grpcio
-protobuf
+protobuf==3.17.3
 Jinja2
 mljar-supervised
 dill


### PR DESCRIPTION
* use specific protobuf versions
* use submodule autogluon.tabular for now to save container build time
  * we can change that later as we only support tabular data for now anyway


@bican-guel this should drastically improve container build times