### PR TITLE
Fix Type-Hints in DataSetAnalysisManager

### DIFF
--- a/controller/managers/DataSetAnalysisManager.py
+++ b/controller/managers/DataSetAnalysisManager.py
@@ -91,7 +91,7 @@ class DataSetAnalysisManager:
         return na_counts
 
     @staticmethod
-    def __missing_values_rows(dataset: pd.DataFrame) -> list(int):
+    def __missing_values_rows(dataset: pd.DataFrame) -> 'list[int]':
         """
         Counts missing values of each row and adds the indices of rows with a lot of missing values to a list
         ---
@@ -113,7 +113,7 @@ class DataSetAnalysisManager:
         return missing_rows_indices
 
     @staticmethod
-    def __detect_outliers(dataset: pd.DataFrame) -> list(dict):
+    def __detect_outliers(dataset: pd.DataFrame) -> 'list[dict]':
         """
         Detects outliers in all columns in a dataset containing floats
         ---


### PR DESCRIPTION
@rnbndr complex type hints need to be wrapped in quotes, eg. ` 'dict[str, int]'` or `'list[str]'`