### PR TITLE
Increase MongoDB Connection Timetout

### DIFF
--- a/controller/persistence/mongo_client.py
+++ b/controller/persistence/mongo_client.py
@@ -36,7 +36,7 @@ class Database:
             #       --> eg. "mongodb://root:example@mongo"
             mongo = MongoClient(server_url, 27017,
                 # timeout to find a database server
-                serverSelectionTimeoutMS=1000)
+                serverSelectionTimeoutMS=3000)
             
             # we want to fail as fast as possible when the database is not reachable.
             #   by default pymongo will lazy initialize and waits for the first 'real' database 


### PR DESCRIPTION
Timeout value is too low, when starting system with Makefile the controller will sometimes try to connect to mongoDB when it is not launched yet.