### PR TITLE
AutoGluon Implementation of image classification task with custom data_loader

### DIFF
--- a/adapters/AutoGluon/AutoGluonServer.py
+++ b/adapters/AutoGluon/AutoGluonServer.py
@@ -6,6 +6,7 @@ import time
 import shutil
 
 from autogluon.tabular import TabularPredictor
+from autogluon.vision import ImagePredictor, ImageDataset
 
 import Adapter_pb2
 import Adapter_pb2_grpc
@@ -13,7 +14,88 @@ import Adapter_pb2_grpc
 from concurrent import futures
 from JsonUtil import get_config_property
 
+
 from AdapterUtils import *
+
+
+def data_loader(config):
+    """
+    Get exception message
+    ---
+    Parameter
+    1. config: Job config
+    ---
+    Return job type specific dataset
+    """
+    train_data = None
+    test_data = None
+
+    if config["task"] == 1:
+        train_data, test_data = read_tabular_dataset_training_data(config)
+    elif config["task"] == 2:
+        train_data, test_data = read_tabular_dataset_training_data(config)
+    elif config["task"] == 3:
+        train_data, test_data = None
+    elif config["task"] == 4:
+        train_data, test_data = read_image_dataset(config)
+    elif config["task"] == 5:
+        train_data, test_data = read_image_dataset(config)
+
+    return train_data, test_data
+
+
+
+def AutoGluon_data_loader():
+
+    """
+    Get exception message
+    ---
+    Parameter
+    1. config: Job config
+    ---
+    Return job type specific dataset
+    """
+    train_data = None
+    test_data = None
+
+    if config["task"] == 1:
+        train_data, test_data = read_tabular_dataset_training_data(config)
+    elif config["task"] == 2:
+        train_data, test_data = read_tabular_dataset_training_data(config)
+    elif config["task"] == 3:
+        train_data, test_data = None
+    elif config["task"] == 4:
+        train_data, test_data = read_image_dataset_auto_gluon(config)
+    
+    return train_data, test_data
+
+def read_image_dataset_auto_gluon():
+
+    """Reads image data and return sets
+    ---
+    Parameter
+    1. config: Job config
+    ---
+    Return image dataset
+    """
+
+    local_dir_path = json_configuration["file_location"]
+
+    data_dir = os.path.join(local_dir_path, json_configuration["file_name"])
+    train_data = None
+    test_data = None
+
+    if(json_configuration["test_configuration"]["dataset_structure"] == 1):
+
+        all_data = ImageDataset.from_folder(data_dir)
+        train_data, val_data, test_data = all_data.random_split(val_size=json_configuration["test_configuration"]["split_ratio"], test_size=json_configuration["test_configuration"]["split_ratio"])
+
+
+    else:
+        train_data, val_data, test_data = ImageDataset.from_folders(data_dir)
+
+    return train_data, test_data
+
 
 def GetMetaInformations(config_json):
     working_dir = os.path.join(get_config_property("output-path"), "working_dir")
@@ -70,7 +152,7 @@ class AdapterServiceServicer(Adapter_pb2_grpc.AdapterServiceServicer):
 
 
             library, model = GetMetaInformations(config_json)
-            test_score, prediction_time= evaluate(config_json, job_file_location)
+            test_score, prediction_time= evaluate(config_json, job_file_location,AutoGluon_data_loader)
             response = yield from get_response(output_json, start_time, test_score, prediction_time, library, model)
 
             print(f'{get_config_property("adapter-name")} job finished')
@@ -105,6 +187,23 @@ def serve():
     Adapter_pb2_grpc.add_AdapterServiceServicer_to_server(AdapterServiceServicer(), server)
     server.add_insecure_port(f'{get_config_property("grpc-server-address")}:{os.getenv("GRPC_SERVER_PORT")}')
     server.start()
+
+    # ToDo:
+    # - Make image tasks available in frontend 
+    # - Test image task application wide
+    # 
+    # Local testing
+    # channel = grpc.insecure_channel(f'{get_config_property("grpc-server-address")}:{os.getenv("GRPC_SERVER_PORT")}')
+    # stub = Adapter_pb2_grpc.AdapterServiceStub(channel)
+    # request = Adapter_pb2.StartAutoMLRequest() 
+    # 
+    # job_file_location = os.path.join(get_config_property("job-file-path"),
+    #                                 get_config_property("job-file-name"))
+    # with open(job_file_location) as file:
+    #     request.processJson = json.dumps(json.load(file))
+    # 
+    # response = stub.StartAutoML(request)
+
     print(get_config_property("adapter-name") + " started")
     server.wait_for_termination()
 

--- a/adapters/AutoGluon/AutoMLs/AutoGluonAdapter.py
+++ b/adapters/AutoGluon/AutoMLs/AutoGluonAdapter.py
@@ -3,7 +3,10 @@ from autogluon.tabular import TabularDataset, TabularPredictor
 from JsonUtil import get_config_property
 from AbstractAdapter import AbstractAdapter
 from AdapterUtils import read_tabular_dataset_training_data, prepare_tabular_dataset, export_model
+from AutoGluonServer.py import data_loader
+import shutil
 
+from autogluon.vision import ImagePredictor, ImageDataset
 
 class AutoGluonAdapter(AbstractAdapter):
     """
@@ -18,7 +21,32 @@ class AutoGluonAdapter(AbstractAdapter):
         1. Configuration JSON of type dictionary
         """
         super().__init__(configuration)
+
+
+        """
+        self._configuration = configuration
+
+        # set runtime limit from configuration, if it isn't specified its set to 30s
+        if self._configuration["runtime_constraints"]["runtime_limit"] > 0:
+            self._time_limit = self._configuration["runtime_constraints"]["runtime_limit"]
+        else:
+            self._time_limit = 30
+
+        # Interne spalten für Tabellen
+        self._target = self._configuration["tabular_configuration"]["target"]["target"]
+
+
+        # Maximum Itteration set to 3 if 0
+        if self._configuration["runtime_constraints"]["max_iter"] == 0:
+            self._max_iter = self._configuration["runtime_constraints"]["max_iter"] = 3
+
+        # Erstelle den pfad der später verwendet wird.
+        os.mkdir(os.path.join(get_config_property("output-path"), self._configuration["session_id"]))
+
+        """
+
         self._result_path = os.path.join(get_config_property("output-path"), configuration["session_id"], "model_gluon.gluon")
+        # this only sets the result path tbh.
 
     def start(self):
         """
@@ -30,6 +58,8 @@ class AutoGluonAdapter(AbstractAdapter):
             self.__tabular_classification()
         elif self._configuration["task"] == 2:
             self.__tabular_regression()
+        elif self._configuration["task"] == 4:
+            self.__image_classification()
 
     def __tabular_classification(self):
         """
@@ -60,3 +90,26 @@ class AutoGluonAdapter(AbstractAdapter):
             data,
             time_limit=self._time_limit)
         #Fit methode already saves the model
+
+    def __image_classification(self):
+        """
+        Execute the classiciation task
+        """
+        # Daten Laden 
+        train , test = data_loader(self._configuration)
+        
+        # Einteilen 
+        set_hyperparameters={ 
+            'batch_size': self._configuration["test_configuration"]["batch_size"], 
+            'epochs': self._configuration["runtime_constraints"]["epochs"] 
+            }
+        
+        model = ImagePredictor(
+            label=self._target,
+            path=self._result_path)
+        
+         # Trainieren 
+        model.fit(
+            train , 
+            hyperparameters=set_hyperparameters , 
+            time_limit = self._configuration["runtime_constraints"]["runtime_limit"]  ) 


### PR DESCRIPTION
This is the Implementation only can be tested or works with either branch 68 or 108 adding the different implementation for evaluate that requires the data loader. 

It implements the Image Classification task for AutoGluon and assumes to get a folder destination with one of two underlying structures. either test, train folders in the configuration location or images set in classes directly (instead of inside the test and train folders.)

