### PR TITLE
#146 Metadata of longitudinal datasets

### DIFF
--- a/controller/managers/DataSetAnalysisManager.py
+++ b/controller/managers/DataSetAnalysisManager.py
@@ -59,8 +59,10 @@ class DataSetAnalysisManager:
         analysis = {"basic_analysis": "", "advanced_analysis": ""}
 
         if self.config["type"] == ":time_series_longitudinal":
-            analysis["basic_analysis"] = self.startLongitudinalDataAnalysis()
-
+            try:
+                analysis["basic_analysis"] = self.longitudinal_analysis()
+            except:
+                analysis["basic_analysis"] = ""
         else:
             if basic_analysis:
                 try:
@@ -429,11 +431,13 @@ class DataSetAnalysisManager:
                 "path": filename}
 
 
-    def startLongitudinalDataAnalysis(self) -> dict:
-        rows, cols = self.__dataset.shape
+    def longitudinal_analysis(self) -> dict:
+        instances, dimensions = self.__dataset.shape
+        series_length = len(self.__dataset.loc[0][0])
         return {
-            "number_of_columns": cols,
-            "number_of_rows": rows,
+            "number_of_columns": dimensions - 1,
+            "number_of_rows": instances,
+            "series_length": series_length,
             "na_columns": {},
             "high_na_rows": [],
             "outlier": [],

--- a/frontend/src/Server/BlazorBoilerplate.Server/Localization/de-DE.po
+++ b/frontend/src/Server/BlazorBoilerplate.Server/Localization/de-DE.po
@@ -549,6 +549,15 @@ msgstr "Reihenanzahl: {0}"
 msgid "Number of columns: {0}"
 msgstr "Spaltenanzahl: {0}"
 
+msgid "Number of instances: {0}"
+msgstr "Anzahl Instanzen: {0}"
+
+msgid "Number of dimensions: {0}"
+msgstr "Dimensionen: {0}"
+
+msgid "Series length: {0}"
+msgstr "Länge der Zeitreihen: {0}"
+
 msgid "New Training"
 msgstr "Neues Training"
 

--- a/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
+++ b/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
@@ -1371,6 +1371,18 @@ msgid "Number of columns: {0}"
 msgstr "Number of columns: {0}"
 
 msgctxt "Global"
+msgid "Number of instances: {0}"
+msgstr "Number of instances: {0}"
+
+msgctxt "Global"
+msgid "Number of dimensions: {0}"
+msgstr "Number of dimensions: {0}"
+
+msgctxt "Global"
+msgid "Series length: {0}"
+msgstr "Series length: {0}"
+
+msgctxt "Global"
 msgid "New Training"
 msgstr "New Training"
 
@@ -1636,7 +1648,7 @@ msgstr "Task"
 
 msgctxt "Global"
 msgid "Dataset not redable"
-msgstr "Dataset couln´t be read, use the preview config option to reconfigure the dataset."
+msgstr "Dataset coulnï¿½t be read, use the preview config option to reconfigure the dataset."
 
 msgctxt "Global"
 msgid "Start: {0}"

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Dataset.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Dataset.razor
@@ -41,7 +41,7 @@
                             </MudItem>
                             <MudItem xs="3" sm="3" md="3">
                                 <MudText Typo="Typo.body1">@L["File Size: {0}", FormatBytes(_dataset.Size)]</MudText>
-                                @if ((@_dataset.Type.ID == ":tabular") || (@_dataset.Type.ID == ":text") || (@_dataset.Type.ID == ":time_series") || (@_dataset.Type.ID == ":time_series_longitudinal"))
+                                @if ((@_dataset.Type.ID == ":tabular") || (@_dataset.Type.ID == ":text") || (@_dataset.Type.ID == ":time_series"))
                                 {
                                     if (_dataset.Analysis == null)
                                     {
@@ -57,6 +57,26 @@
                                     {
                                         <MudText Typo="Typo.body1">@L["Number of rows: {0}", "unknown"]</MudText>
                                         <MudText Typo="Typo.body1">@L["Number of columns: {0}", "unknown"]</MudText>
+                                    }
+                                } else if (@_dataset.Type.ID == ":time_series_longitudinal")
+                                {
+                                    if (_dataset.Analysis == null)
+                                    {
+                                        <MudText Typo="Typo.body1">@L["Number of instances: {0}", "unknown"]</MudText>
+                                        <MudText Typo="Typo.body1">@L["Number of dimensions: {0}", "unknown"]</MudText>
+                                        <MudText Typo="Typo.body1">@L["Series length: {0}", "unknown"]</MudText>
+                                    }
+                                    else if (_dataset.Analysis.Count != 0)
+                                    {
+                                        <MudText Typo="Typo.body1">@L["Number of instances: {0}", _dataset.Analysis["basic_analysis"]["number_of_rows"]]</MudText>
+                                        <MudText Typo="Typo.body1">@L["Number of dimensions: {0}", _dataset.Analysis["basic_analysis"]["number_of_columns"]]</MudText>
+                                        <MudText Typo="Typo.body1">@L["Series length: {0}", _dataset.Analysis["basic_analysis"]["series_length"]]</MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudText Typo="Typo.body1">@L["Number of instances: {0}", "unknown"]</MudText>
+                                        <MudText Typo="Typo.body1">@L["Number of dimensions: {0}", "unknown"]</MudText>
+                                        <MudText Typo="Typo.body1">@L["Series length: {0}", "unknown"]</MudText>
                                     }
                                 }
                             </MudItem>


### PR DESCRIPTION
This change adds new text blocks to display the metadata of longitudinal datasets on the data preview screen.

**Screenshot:**

![image](https://user-images.githubusercontent.com/22834492/194250252-40449d6f-f073-4416-9576-c7f62f4047a5.png)


