### PR TITLE
Close Files When Generating Templates

### DIFF
--- a/adapters/Utils/Utils/TemplateGenerator.py
+++ b/adapters/Utils/Utils/TemplateGenerator.py
@@ -28,11 +28,11 @@ class TemplateGenerator(object):
         # Render Python script
         with open(os.path.join(self.__TEMPLATES_PATH, 'predict.ji')) as file:
             template = Template(file.read())
-        script_file = open(os.path.join(self.__OUTPUT_PATH, 'predict.py'), "w")
-        script_file.write(template.render(task=self._configuration))
+        with open(os.path.join(self.__OUTPUT_PATH, 'predict.py'), "w") as script_file:
+            script_file.write(template.render(task=self._configuration))
 
         # Render Requirement.txt
         with open(os.path.join(self.__TEMPLATES_PATH, 'requirements.ji')) as file:
             template = Template(file.read())
-        script_file = open(os.path.join(self.__OUTPUT_PATH, 'requirements.txt'), "w")
-        script_file.write(template.render())
+        with open(os.path.join(self.__OUTPUT_PATH, 'requirements.txt'), "w") as script_file:
+            script_file.write(template.render())


### PR DESCRIPTION
Files left open were cause of warnings:
```
adapters/Utils/Utils/TemplateGenerator.py:37: ResourceWarning: unclosed file <_io.TextIOWrapper name='app-data/training/e1d36b1b-bb75-4f16-a631-d93bdb31e9c7/63538f02a8499d239605e4c3/63650604550f952c84d49b06/result/predict.py' mode='w' encoding='UTF-8'>
  script_file = open(os.path.join(self.__OUTPUT_PATH, 'requirements.txt'), "w")
ResourceWarning: Enable tracemalloc to get the object allocation traceback
adapters/Utils/Utils/AdapterUtils.py:172: ResourceWarning: unclosed file <_io.TextIOWrapper name='app-data/training/e1d36b1b-bb75-4f16-a631-d93bdb31e9c7/63538f02a8499d239605e4c3/63650604550f952c84d49b06/result/requirements.txt' mode='w' encoding='UTF-8'>
  generator.generate_script()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```