### PR TITLE
Add editorconfig to formalize and automate whitespace conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+tab_width = 4
+
+[*.py]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*.proto]
+indent_style = space
+indent_size = 2
+tab_width = 2

--- a/controller/.vscode/extensions.json
+++ b/controller/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "ms-python.vscode-pylance",
         "ms-azuretools.vscode-docker",
         "njpwerner.autodocstring",
-        "stardog-union.stardog-rdf-grammars"
+        "stardog-union.stardog-rdf-grammars",
+        "EditorConfig.EditorConfig"
     ]
 }


### PR DESCRIPTION
Just a small PR that configures all IDEs to follow the whitespace conventions. VS-Code requires an extension to support this, which is why the corresponding extension was added to the recommended extensions of the controller project. This is not a linter or formatter, it only makes following the conventions easier, because it lets the IDEs follow them automatically. 

.NET also allows configuring warnings and naming conventions in the .editorconfig, that was not done in this PR though.