### PR TITLE
Fixing the python-environment path for UNIX in all adapters.

### DIFF
--- a/adapters/AutoCVE/.vscode/launch.json
+++ b/adapters/AutoCVE/.vscode/launch.json
@@ -14,7 +14,7 @@
             "env": {
                 "PYTHONPATH": "AutoMLs;Utils;../Utils/Utils;../Utils/AutoMLs;../GRPC/Adapter;",
                 "GRPC_SERVER_PORT": "50058",
-                "PYTHON_ENV": ".venv/Scripts/python",
+                "PYTHON_ENV": ".venv/bin/python",
                 "USE_DEV_CONFIG": "YES"
             },
         }

--- a/adapters/AutoGluon/.vscode/launch.json
+++ b/adapters/AutoGluon/.vscode/launch.json
@@ -28,7 +28,7 @@
             "env": {
                 "PYTHONPATH": ".:dependency-injection:AutoMLs:Utils:../Utils/Utils:../Utils/AutoMLs:../GRPC/Adapter:",
                 "GRPC_SERVER_PORT": "50057",
-                "PYTHON_ENV": ".venv/Scripts/python",
+                "PYTHON_ENV": ".venv/bin/python",
                 "USE_DEV_CONFIG": "YES"
             },
         }

--- a/adapters/AutoKeras/.vscode/launch.json
+++ b/adapters/AutoKeras/.vscode/launch.json
@@ -29,7 +29,7 @@
             "env": {
                 "PYTHONPATH": ".:dependency-injection:AutoMLs:Utils:../Utils/Utils:../Utils/AutoMLs:../GRPC/Adapter:",
                 "GRPC_SERVER_PORT": "50052",
-                "PYTHON_ENV": ".venv/Scripts/python",
+                "PYTHON_ENV": ".venv/bin/python",
                 "USE_DEV_CONFIG": "YES",
                 "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python"
             },

--- a/adapters/EvalML/.vscode/launch.json
+++ b/adapters/EvalML/.vscode/launch.json
@@ -28,7 +28,7 @@
             "env": {
                 "PYTHONPATH": ".:dependency-injection:AutoMLs:Utils:../Utils/Utils:../Utils/AutoMLs:../GRPC/Adapter:",
                 "GRPC_SERVER_PORT": "50061",
-                "PYTHON_ENV": ".venv/Scripts/python",
+                "PYTHON_ENV": ".venv/bin/python",
                 "USE_DEV_CONFIG": "YES"
             },
         }

--- a/adapters/FLAML/.vscode/launch.json
+++ b/adapters/FLAML/.vscode/launch.json
@@ -28,7 +28,7 @@
             "env": {
                 "PYTHONPATH": ".:dependency-injection:AutoMLs:Utils:../Utils/Utils:../Utils/AutoMLs:../GRPC/Adapter:",
                 "GRPC_SERVER_PORT": "50056",
-                "PYTHON_ENV": ".venv/Scripts/python",
+                "PYTHON_ENV": ".venv/bin/python",
                 "USE_DEV_CONFIG": "YES"
             },
         }

--- a/adapters/MLJAR/.vscode/launch.json
+++ b/adapters/MLJAR/.vscode/launch.json
@@ -28,7 +28,7 @@
             "env": {
                 "PYTHONPATH": ".:dependency-injection:AutoMLs:Utils:../Utils/Utils:../Utils/AutoMLs:../GRPC/Adapter:",
                 "GRPC_SERVER_PORT": "50053",
-                "PYTHON_ENV": ".venv/Scripts/python",
+                "PYTHON_ENV": ".venv/bin/python",
                 "USE_DEV_CONFIG": "YES"
             },
         }

--- a/adapters/Mcfly/.vscode/launch.json
+++ b/adapters/Mcfly/.vscode/launch.json
@@ -25,7 +25,7 @@
             "env": {
                 "PYTHONPATH": ".:dependency-injection:AutoMLs:Utils:../Utils/Utils:../Utils/AutoMLs:../GRPC/Adapter:",
                 "GRPC_SERVER_PORT": "50061",
-                "PYTHON_ENV": ".venv/Scripts/python",
+                "PYTHON_ENV": ".venv/bin/python",
                 "USE_DEV_CONFIG": "YES"
             },
         }


### PR DESCRIPTION
The path to the python environment was wrong in most adapters for UNIX systems, this has been corrected here.