### PR TITLE
Fixed bug in en-US.po

### DIFF
--- a/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
+++ b/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
@@ -165,7 +165,7 @@ msgstr "Read clients data"
 
 msgctxt "Global"
 msgid "ReadRolePermission"
-msgstr "Read roles data (permissions, etc.")"
+msgstr "Read roles data (permissions, etc.)"
 
 msgctxt "Global"
 msgid "ReadUserPermission"


### PR DESCRIPTION
A quotation mark in the en-US.po file caused that the frontend would't work in the english language.