### PR TITLE
Fix python indentation (should be spaces. Not tabs)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,14 +4,7 @@ root = true
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.cs]
 indent_style = space
-indent_size = 4
-tab_width = 4
-
-[*.py]
-indent_style = tab
 indent_size = 4
 tab_width = 4
 


### PR DESCRIPTION
Sets the indentation of python files to spaces instead of tabs, matching the existing files. The coding guidelines have to be updated after this PR