### PR TITLE
Fix AutoKeras Integration Tests

### DIFF
--- a/adapters/AutoKeras/tests/test_tabular_tasks.py
+++ b/adapters/AutoKeras/tests/test_tabular_tasks.py
@@ -75,7 +75,15 @@ class AutoKerasTabularTaskTest(unittest.TestCase):
                 "delimiter": "comma",
                 "escape_character": "\\",
                 "decimal_character": ".",
+                "thousands_seperator": ",",
+                "datetime_format": "",
                 "encoding": ""
+            },
+            "schema": {
+                "survived": {
+                    "datatype_detected": ":boolean",
+                    "role_selected": ":target"
+                }
             }
         })
 
@@ -120,7 +128,15 @@ class AutoKerasTabularTaskTest(unittest.TestCase):
                 "delimiter": "comma",
                 "escape_character": "\\",
                 "decimal_character": ".",
+                "thousands_seperator": ",",
+                "datetime_format": "",
                 "encoding": ""
+            },
+            "schema": {
+                "survived": {
+                    "datatype_detected": ":boolean",
+                    "role_selected": ":target"
+                }
             }
         })
 


### PR DESCRIPTION
Changes in AutoMLRequest made the tests fail.

Dataset Configuration was extended to accomodate new fields.