### PR TITLE
Wiki tooltip wrap any component

### DIFF
--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/WikiTooltip.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/WikiTooltip.razor
@@ -17,12 +17,7 @@
                 <MudItem xs="12">
                     <MudText Style="font-size:inherit">@InfoText</MudText>
                 </MudItem>
-
-
             </MudGrid>
-
-
-
         </TooltipContent>
     </MudTooltip>
 }
@@ -79,6 +74,4 @@ else
         public string Text { get; set; }
         public string ImageUrl { get; set; }
     }
-
 }
-

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/WikiTooltip.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/WikiTooltip.razor
@@ -2,7 +2,14 @@
 {
     <MudTooltip Text="SeeAlso" Delay="600" Arrow="true" Placement="Placement.Top" Class="strategy-description-tooltip">
         <ChildContent>
-            <MudText>@Label</MudText>
+            @if (ChildContent != null)
+            {
+                @ChildContent
+            }
+            else
+            {
+                <MudText>@Label</MudText>
+            }
         </ChildContent>
 
         <TooltipContent>
@@ -23,7 +30,14 @@
 }
 else
 {
-    <MudText>@Label</MudText>
+    @if (ChildContent != null)
+    {
+        @ChildContent
+    }
+    else
+    {
+        <MudText>@Label</MudText>
+    }
 }
 
 @code {
@@ -35,6 +49,9 @@ else
 
     [Parameter]
     public string Label { get; set; }
+
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
 
     public string ImageUrl;
     public string InfoText;

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Wizard/General/ChipSet.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Wizard/General/ChipSet.razor
@@ -7,9 +7,9 @@
         {
             @if (!string.IsNullOrEmpty(chip.ToolTip) || !string.IsNullOrEmpty(chip.Comment))
             {
-                <MudChip Value="@chip.Id" Text="@chip.Label" Variant="Variant.Text" Color="Color.Secondary" @onclick="() => ToggleChip(chip)">
-                    <WikiTooltip SeeAlso="@chip.ToolTip" Comment="@chip.Comment" Label="@chip.Label" />
-                </MudChip>
+                <WikiTooltip SeeAlso="@chip.ToolTip" Comment="@chip.Comment">
+                    <MudChip Value="@chip.Id" Text="@chip.Label" Variant="Variant.Text" Color="Color.Secondary" @onclick="() => ToggleChip(chip)" />
+                </WikiTooltip>
             }
             else
             {

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Wizard/General/ChipSet.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Wizard/General/ChipSet.razor
@@ -8,15 +8,7 @@
             @if (!string.IsNullOrEmpty(chip.ToolTip) || !string.IsNullOrEmpty(chip.Comment))
             {
                 <MudChip Value="@chip.Id" Text="@chip.Label" Variant="Variant.Text" Color="Color.Secondary" @onclick="() => ToggleChip(chip)">
-
-                    <WikiTooltip SeeAlso="@chip.ToolTip" Comment="@chip.Comment" Label="@chip.Label">
-
-                    </WikiTooltip>
-
-                    <!--   else
-                    {
-                        <MudChip Value="@chip.Id" Text="@chip.Label" Variant="Variant.Text" Color="Color.Secondary" @onclick="() => ToggleChip(chip)" />
-                    }-->
+                    <WikiTooltip SeeAlso="@chip.ToolTip" Comment="@chip.Comment" Label="@chip.Label" />
                 </MudChip>
             }
             else


### PR DESCRIPTION
Modify the WikiTooltip component to support wrapping any component (instead of only being able to receive a text value). This change was made to support tool tips in the auto ml parameters in the wizard. Those won't be finished until tomorrow though. Therefore this PR only contains this small improvement.