### PR TITLE
Ux improvements - Breadcrumbs fixed

### DIFF
--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Dataset.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Dataset.razor
@@ -8,13 +8,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.ListAlt" />
     <MudText Typo="Typo.h4">@_pageTitle</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Dataset.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Dataset.razor
@@ -6,15 +6,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetAnalysis.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetAnalysis.razor
@@ -8,13 +8,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.ListAlt" />
     <MudText Typo="Typo.h4">@_pageTitle</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetAnalysis.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetAnalysis.razor
@@ -6,15 +6,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetPreview.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetPreview.razor
@@ -8,13 +8,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.ListAlt" />
     <MudText Typo="Typo.h4">@_pageTitle</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetPreview.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetPreview.razor
@@ -6,15 +6,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Datasets.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Datasets.razor
@@ -7,15 +7,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Datasets.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Datasets.razor
@@ -9,13 +9,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.ListAlt" />
     <MudText Typo="Typo.h4">@L["Datasets"]</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
@@ -9,13 +9,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.Home" />
     <MudText Typo="Typo.h4">Home</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
@@ -7,15 +7,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Model.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Model.razor
@@ -11,13 +11,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.Lightbulb" />
     @if (_model != null)
     {

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Model.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Model.razor
@@ -9,15 +9,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelDetails.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelDetails.razor
@@ -7,15 +7,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelDetails.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelDetails.razor
@@ -9,13 +9,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.Lightbulb" />
     <MudText Typo="Typo.h4">Details</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelExplanation.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelExplanation.razor
@@ -10,13 +10,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.Lightbulb" />
     <MudText Typo="Typo.h4">@L["Analysis"]</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelExplanation.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/ModelExplanation.razor
@@ -8,15 +8,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Models.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Models.razor
@@ -6,15 +6,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Models.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Models.razor
@@ -8,14 +8,17 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.Lightbulb" />
     <MudText Typo="Typo.h4">Models</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Training.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Training.razor
@@ -6,15 +6,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Training.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Training.razor
@@ -8,13 +8,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.ModelTraining"/>
     <MudText Typo="Typo.h4">@_pageTitle</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Trainings.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Trainings.razor
@@ -8,13 +8,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.ModelTraining"/>
     <MudText Typo="Typo.h4">Trainings</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Trainings.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Trainings.razor
@@ -6,15 +6,7 @@
 @attribute [Authorize]
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Wizard.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Wizard.razor
@@ -10,13 +10,16 @@
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" style="
     position: fixed!important;
-    top: 65px;
+    top: 3.3rem;
     z-index: 999!important;
-    width: 100%;">
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;">
     </MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:30px">
+<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.ModelTraining"/>
     <MudText Typo="Typo.h4">@L["Train"]</MudText>
 </MudStack>

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Wizard.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Wizard.razor
@@ -8,15 +8,7 @@
 
 
 <TopSection>
-    <MudBreadcrumbs Items="_breadcrumbs" style="
-    position: fixed!important;
-    top: 3.3rem;
-    z-index: 999!important;
-    width: 100%;
-    height: 4.3rem;
-    background: white;
-    border-bottom: 1px solid lightgrey;">
-    </MudBreadcrumbs>
+    <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/wwwroot/css/site.css
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/wwwroot/css/site.css
@@ -77,3 +77,13 @@ a {
 .mud-overlay.mud-overlay-dialog {
     z-index: 99;
 }
+
+.mudbreadcrumbs {
+    position: fixed !important;
+    top: 3.3rem;
+    z-index: 999 !important;
+    width: 100%;
+    height: 4.3rem;
+    background: white;
+    border-bottom: 1px solid lightgrey;
+}


### PR DESCRIPTION
Breadcrumbs no longer overlay content.
A separator line was added to improve visual recognition.
Size got increased to fit two lines with small screens.
Code outsourced into site.css file to avoid redundant code.