### PR TITLE
Disable empty dropbox, refactor add placeholder

### DIFF
--- a/frontend/src/Server/BlazorBoilerplate.Server/Managers/DatasetManager.cs
+++ b/frontend/src/Server/BlazorBoilerplate.Server/Managers/DatasetManager.cs
@@ -1,35 +1,13 @@
-using Azure;
-using BlazorBoilerplate.Constants;
 using BlazorBoilerplate.Infrastructure.Server;
 using BlazorBoilerplate.Infrastructure.Server.Models;
 using BlazorBoilerplate.Shared.Dto.Dataset;
 using BlazorBoilerplate.Shared.Dto.Ontology;
 using BlazorBoilerplate.Storage;
-using Grpc.Core;
-using Grpc.Net.Client;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Data.Analysis;
-using Microsoft.Extensions.Logging;
-using MudBlazor.Charts;
 using Newtonsoft.Json;
-using Serilog.Core;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 using UtfUnknown;
 using static Microsoft.AspNetCore.Http.StatusCodes;
 using System.IO.Compression;
-using System.Runtime.CompilerServices;
-using Karambolo.Common;
-using System.Diagnostics;
-using static MudBlazor.CategoryTypes;
 
 namespace BlazorBoilerplate.Server.Managers
 {

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Model.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Model.razor
@@ -60,7 +60,7 @@
                                 <MudText Typo="Typo.body1">@L["Training emissions: {0} g CO2-eq", String.Format("{0:0.00}", _model.Model.Emissions)]</MudText>
                             </MudItem>
                             <MudItem xs="3" sm="3" md="3">
-                                <MudSelect Label="@L["Metric"]" T="string" @bind-Value=SelectedMetric>
+                                <MudSelect Disabled=@IsDisabled Label="@L["Metric"]" T="string" @bind-Value=SelectedMetric>
                                     @foreach (var metric in _model.Model.Metrics)
                                     {
                                         <MudSelectItem Value="@metric.Name.ID">
@@ -126,6 +126,7 @@
     private GetTrainingResponseDto _training;
     private GetDatasetResponseDto _dataset;
     private List<BreadcrumbItem> _breadcrumbs = new List<BreadcrumbItem>();
+	protected bool IsDisabled { get; set; }
 
     protected async override void OnInitialized()
     {
@@ -156,6 +157,7 @@
     }
     private async Task LoadModel()
     {
+		IsDisabled = true;
         try
         {
             ApiResponseDto apiResponse;
@@ -176,6 +178,7 @@
                 if (_model.Model.Metrics.Count > 0 && SelectedMetric == "")
                 {
                     SelectedMetric = _model.Model.Metrics[0].Name.ID;
+					IsDisabled = false;
                 }
                 //Get Training infos
                 apiResponse = await apiClient.GetTraining(new GetTrainingRequestDto() { TrainingId = _model.Model.TrainingId });

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Models/AllModels.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Models/AllModels.razor
@@ -59,7 +59,7 @@
                                                                                                 <MudTh></MudTh>
                                                                                                 <MudTh></MudTh>
                                                                                                 <MudTh>
-                                                                                                    <MudSelect T="string" @bind-Value=SelectedMetric>
+                                                                                                    <MudSelect Disabled=@IsDisabled Label="@L["Metric"]" T="string" @bind-Value=SelectedMetric>
                                                                                                         @foreach (var metric in _metrics)
                                                                                                         {
                                                                                                             <MudSelectItem Value="@metric.Name.ID">
@@ -138,50 +138,53 @@
 </MudCard>
 
 @code {
-    [Parameter]
-    public EventCallback OnDeleteModelCompleted { get; set; }
-    [Parameter]
-    public string DatasetId { get; set; }
-    [Parameter]
-    public GetModelsResponseDto Models
-    {
-        get
-        {
-            return _models;
-        }
-        set
-        {
-            _models = value;
-            if (_models != null)
-            {
-                UpdateMetricsList();
-                StateHasChanged();
-            }
-        }
-    }
-    private string searchString = "";
-    private GetModelsResponseDto _models;
-    private List<Metric> _metrics = new List<Metric>();
-    private string SelectedMetric { get; set; } = "";
+	[Parameter]
+	public EventCallback OnDeleteModelCompleted { get; set; }
+	[Parameter]
+	public string DatasetId { get; set; }
+	[Parameter]
+	public GetModelsResponseDto Models
+	{
+		get
+		{
+			return _models;
+		}
+		set
+		{
+			_models = value;
+			if (_models != null)
+			{
+				UpdateMetricsList();
+				StateHasChanged();
+			}
+		}
+	}
+	private string searchString = "";
+	private GetModelsResponseDto _models;
+	private List<Metric> _metrics = new List<Metric>();
+	private string SelectedMetric { get; set; } = "";
+	protected bool IsDisabled { get; set; }
 
-    private void UpdateMetricsList()
-    {
-        foreach (var model in _models.Models)
-        {
-            foreach (var metric in model.Metrics)
-            {
-                if (_metrics.Where(x => x.Name.Properties["skos:prefLabel"] == metric.Name.Properties["skos:prefLabel"]).Count() == 0)
-                {
-                    _metrics.Add(metric);
-                }
-            }
-        }
-        _metrics = _metrics.OrderBy(x => x.Name.Properties["skos:prefLabel"]).ToList();
-        if (_metrics.Count > 0 && SelectedMetric == "")
-        {
-            SelectedMetric = _metrics[0].Name.ID;
-            StateHasChanged();
-        }
+	private void UpdateMetricsList()
+	{
+		IsDisabled = true;
+		foreach (var model in _models.Models)
+		{
+			foreach (var metric in model.Metrics)
+			{
+				if (_metrics.Where(x => x.Name.Properties["skos:prefLabel"] == metric.Name.Properties["skos:prefLabel"]).Count() == 0)
+				{
+					_metrics.Add(metric);
+				}
+			}
+		}
+		_metrics = _metrics.OrderBy(x => x.Name.Properties["skos:prefLabel"]).ToList();
+		if (_metrics.Count > 0 && SelectedMetric == "")
+		{
+			SelectedMetric = _metrics[0].Name.ID;
+			StateHasChanged();
+			IsDisabled = false;
+		}
     }
     private bool FilterFunc(ModelDto element)
     {

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Trainings/TrainingDetails.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Trainings/TrainingDetails.razor
@@ -58,7 +58,7 @@
                             <MudTh></MudTh>
                             <MudTh></MudTh>
                             <MudTh>
-                                <MudSelect T="string" @bind-Value=SelectedMetric>
+                                <MudSelect Disabled=@IsDisabled T="string" Label="@L["Metric"]" @bind-Value=SelectedMetric>
                                     @foreach (var metric in _metrics)
                                     {
                                         <MudSelectItem Value="@metric.Name.ID">
@@ -136,75 +136,78 @@
 </MudCard>
 
 @code {
-    [Parameter]
-    public GetTrainingResponseDto Training
-    {
-        get
-        {
-            return _training;
-        }
-        set
-        {
-            _training = value;
-            if (_training != null)
-            {
-                UpdateMetricsList();
-                RefreshTraining(null, null);
-                _timer = new Timer()
+	[Parameter]
+	public GetTrainingResponseDto Training
+	{
+		get
+		{
+			return _training;
+		}
+		set
+		{
+			_training = value;
+			if (_training != null)
+			{
+				UpdateMetricsList();
+				RefreshTraining(null, null);
+				_timer = new Timer()
                 {
                     AutoReset = true,
                     Enabled = true,
                     Interval = 2000
                 };
-                _timer.Elapsed += RefreshTraining;
-                StateHasChanged();
-            }
-        }
-    }
-    private List<Metric> _metrics = new List<Metric>();
-    private string SelectedMetric { get; set; } = "";
-    private GetTrainingResponseDto _training;
-    private Timer _timer;
-    private string searchString = "";
+				_timer.Elapsed += RefreshTraining;
+				StateHasChanged();
+			}
+		}
+	}
+	private List<Metric> _metrics = new List<Metric>();
+	private string SelectedMetric { get; set; } = "";
+	private GetTrainingResponseDto _training;
+	private Timer _timer;
+	private string searchString = "";
+	protected bool IsDisabled { get; set; }
 
-    private bool FilterFunc(ModelDto element)
-    {
-        if (string.IsNullOrWhiteSpace(searchString))
-            return true;
-        if (element.AutoMlSolution.Properties["skos:prefLabel"].Contains(searchString, StringComparison.OrdinalIgnoreCase))
-            return true;
-        if (element.Status.Contains(searchString, StringComparison.OrdinalIgnoreCase))
-            return true;
-        if (element.GetMlLibraryString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
-            return true;
-        if (element.GetMlModelString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
-            return true;
-        return false;
-    }
-    public void Dispose()
-    {
-        DisposeTimer();
-    }
+	private bool FilterFunc(ModelDto element)
+	{
+		if (string.IsNullOrWhiteSpace(searchString))
+			return true;
+		if (element.AutoMlSolution.Properties["skos:prefLabel"].Contains(searchString, StringComparison.OrdinalIgnoreCase))
+			return true;
+		if (element.Status.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+			return true;
+		if (element.GetMlLibraryString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
+			return true;
+		if (element.GetMlModelString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
+			return true;
+		return false;
+	}
+	public void Dispose()
+	{
+		DisposeTimer();
+	}
 
-    private void UpdateMetricsList()
-    {
-        foreach (var model in _training.Training.models)
-        {
-            foreach (var metric in model.Metrics)
-            {
-                if (_metrics.Where(x => x.Name.Properties["skos:prefLabel"] == metric.Name.Properties["skos:prefLabel"]).Count() == 0)
-                {
-                    _metrics.Add(metric);
-                }
-            }
-        }
-        _metrics = _metrics.OrderBy(x => x.Name.Properties["skos:prefLabel"]).ToList();
-        if (_metrics.Count > 0 && SelectedMetric == "")
-        {
-            SelectedMetric = _metrics[0].Name.ID;
-            StateHasChanged();
-        }
-    }
+	private void UpdateMetricsList()
+	{
+		IsDisabled = true;
+		foreach (var model in _training.Training.models)
+		{
+			foreach (var metric in model.Metrics)
+			{
+				if (_metrics.Where(x => x.Name.Properties["skos:prefLabel"] == metric.Name.Properties["skos:prefLabel"]).Count() == 0)
+				{
+					_metrics.Add(metric);
+				}
+			}
+		}
+		_metrics = _metrics.OrderBy(x => x.Name.Properties["skos:prefLabel"]).ToList();
+		if (_metrics.Count > 0 && SelectedMetric == "")
+		{
+			SelectedMetric = _metrics[0].Name.ID;
+			StateHasChanged();
+			IsDisabled = false;
+		}
+	}
 
     SemaphoreSlim timerSemaphore = new SemaphoreSlim(1);
     private async void RefreshTraining(object sender, ElapsedEventArgs e)


### PR DESCRIPTION
Disable empty dropdown boxes.
Add a placeholder to the Metric dropdown.
Delete unused imports.

close #405

- [ ] If a training session fails, the selection field is empty. Empty selection fields should be disabled. (To make a training fail --> train by ID)
![image](https://github.com/hochschule-darmstadt/MetaAutoML/assets/19534286/293180ba-5453-4751-9ba6-a910731164c3)

- [ ] Successful training sessions generate the usual selection field
![image](https://github.com/hochschule-darmstadt/MetaAutoML/assets/19534286/59f8b41c-9d8f-424b-bff6-60eb4b10cbb5)
