### PR TITLE
Fix: Ignore spaces at end of username and password

### DIFF
--- a/frontend/src/Shared/BlazorBoilerplate.Shared/Models/Account/LoginInputModel.cs
+++ b/frontend/src/Shared/BlazorBoilerplate.Shared/Models/Account/LoginInputModel.cs
@@ -4,9 +4,19 @@ namespace BlazorBoilerplate.Shared.Models.Account
 {
     public class LoginInputModel : AccountFormModel
     {
-        public string UserName { get; set; }
+        private string _userName;
+        public string UserName
+        {
+            get => _userName;
+            set => _userName = value?.Trim();
+        }
 
+        private string _password;
         [DataType(DataType.Password)]
-        public string Password { get; set; }
+        public string Password
+        {
+            get => _password;
+            set => _password = value?.Trim();
+        }
     }
 }

--- a/frontend/src/Shared/BlazorBoilerplate.Shared/Models/Account/Validators/RuleBuilderExtensions.cs
+++ b/frontend/src/Shared/BlazorBoilerplate.Shared/Models/Account/Validators/RuleBuilderExtensions.cs
@@ -16,7 +16,6 @@ namespace BlazorBoilerplate.Shared.Models.Account.Validators
                 .Matches("[a-z]").When(p => PasswordPolicy.RequireLowercase, ApplyConditionTo.CurrentValidator).WithMessage(l["PasswordRequiresLower"])
                 .Matches("[0-9]").When(p => PasswordPolicy.RequireDigit, ApplyConditionTo.CurrentValidator).WithMessage(l["PasswordRequiresDigit"])
                 .Matches("[^a-zA-Z0-9]").When(p => PasswordPolicy.RequireNonAlphanumeric, ApplyConditionTo.CurrentValidator).WithMessage(l["PasswordRequiresNonAlphanumeric"]);
-
             return options;
         }
     }

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor/Pages/Account/Login.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor/Pages/Account/Login.razor
@@ -22,9 +22,11 @@
                         <MudCardHeader>
                             <CardHeaderContent>
                                 <div class="logo">
-                                    <img src=@($"{Module.ContentPath}/images/oma-logo.svg") style="width:100px;" title="@appState.AppName Home" alt="@appState.AppName" />
+                                    <img src=@($"{Module.ContentPath}/images/oma-logo.svg") style="width:100px;"
+                                        title="@appState.AppName Home" alt="@appState.AppName" />
                                     <br />
-                                    <MudText Typo="Typo.h4" Color="Color.Primary" Class="docs-brand-text">@appState.AppName</MudText>
+                                    <MudText Typo="Typo.h4" Color="Color.Primary" Class="docs-brand-text">@appState.AppName
+                                    </MudText>
                                     <br />
                                 </div>
                                 <MudText Typo="Typo.h5" Align="Align.Center">@L["Log in"]</MudText>
@@ -33,17 +35,30 @@
                         <MudCardContent>
                             <FluentValidationValidator />
                             <MudValidationSummary />
-                            <MudTextField AutoFocus="true" @bind-Value="@loginViewModel.UserName" Label=@L["UserName"] AdornmentIcon="@Icons.Material.Filled.Person" Adornment="Adornment.End" FullWidth="true" Required="true" RequiredError=@L["Required"]></MudTextField>
+                            <MudTextField AutoFocus="true" @bind-Value="@loginViewModel.UserName" Label=@L["UserName"]
+                                AdornmentIcon="@Icons.Material.Filled.Person" Adornment="Adornment.End" FullWidth="true"
+                                Required="true" RequiredError=@L["Required"]></MudTextField>
 
-                            <MudTextField @bind-Value="@loginViewModel.Password" Label=@L["Password"] Variant="MudBlazor.Variant.Text" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="PasswordVisibility" AdornmentAriaLabel="Show Password" Adornment="Adornment.End" FullWidth="true" Required="true" RequiredError=@L["Required"] InputType="@PasswordInput"></MudTextField>
+                            <MudTextField @bind-Value="@loginViewModel.Password" Label=@L["Password"]
+                                Variant="MudBlazor.Variant.Text" AdornmentIcon="@PasswordInputIcon"
+                                OnAdornmentClick="PasswordVisibility" AdornmentAriaLabel="Show Password"
+                                Adornment="Adornment.End" FullWidth="true" Required="true" RequiredError=@L["Required"]
+                                InputType="@PasswordInput"></MudTextField>
 
                             @if (loginViewModel.AllowRememberLogin)
-                            {<MudCheckBox @bind-Checked="@loginViewModel.RememberMe" Class="ml-n2">@L["Keep me logged in"]</MudCheckBox>}
+                            {
+                                <MudCheckBox @bind-Checked="@loginViewModel.RememberMe" Class="ml-n2">@L["Keep me logged in"]
+                                </MudCheckBox>
+                            }
                         </MudCardContent>
                         <MudCardActions Class="d-flex align-center flex-grow-1 gap-1">
-                            <MudButton ButtonType="MudBlazor.ButtonType.Submit" Variant="MudBlazor.Variant.Filled" Color="Color.Primary" Class="d-flex flex-1">@L["Login"]</MudButton>
-                                    @if (loginViewModel.EnableRegistration == true)
-                                    {<MudButton OnClick="@Register" Variant="MudBlazor.Variant.Filled" Color="Color.Primary" Class="d-flex flex-1">@L["Sign up"]</MudButton>}
+                            <MudButton ButtonType="MudBlazor.ButtonType.Submit" Variant="MudBlazor.Variant.Filled"
+                                Color="Color.Primary" Class="d-flex flex-1">@L["Login"]</MudButton>
+                            @if (loginViewModel.EnableRegistration == true)
+                            {
+                                <MudButton OnClick="@Register" Variant="MudBlazor.Variant.Filled" Color="Color.Primary"
+                                    Class="d-flex flex-1">@L["Sign up"]</MudButton>
+                            }
                         </MudCardActions>
                     </MudCard>
                 </EditForm>
@@ -60,9 +75,12 @@
                             <EditForm class="pa-4" Model="@forgotPasswordViewModel" OnValidSubmit="@ForgotPassword">
                                 <FluentValidationValidator />
                                 <MudValidationSummary />
-                                <MudTextField @bind-Value="@forgotPasswordViewModel.Email" Label=@L["Email"] AdornmentIcon="@Icons.Material.Outlined.Mail" Adornment="Adornment.End" FullWidth="true" Required="true" RequiredError=@L["Required"]></MudTextField>
+                                <MudTextField @bind-Value="@forgotPasswordViewModel.Email" Label=@L["Email"]
+                                    AdornmentIcon="@Icons.Material.Outlined.Mail" Adornment="Adornment.End" FullWidth="true"
+                                    Required="true" RequiredError=@L["Required"]></MudTextField>
 
-                                <MudButton ButtonType="MudBlazor.ButtonType.Submit" Variant="MudBlazor.Variant.Filled" Color="Color.Primary" Class="my-4" Style="float: right">@L["Submit"]</MudButton>
+                                <MudButton ButtonType="MudBlazor.ButtonType.Submit" Variant="MudBlazor.Variant.Filled"
+                                    Color="Color.Primary" Class="my-4" Style="float: right">@L["Submit"]</MudButton>
                             </EditForm>
                         </ChildContent>
                     </MudExpansionPanel>
@@ -76,9 +94,10 @@
                         <CardHeaderContent>
                             @if (!loginViewModel.EnableLocalLogin)
                             {
-                               
                                 <div class="logo">
-                                    <a href="/" title="@appState.AppName Home"><img src=@($"{Module.ContentPath}/images/logo.svg") style="width:100px;" title="@appState.AppName Home" alt="@appState.AppName" /><br />@appState.AppName</a>
+                                    <a href="/" title="@appState.AppName Home"><img src=@($"{Module.ContentPath}/images/logo.svg")
+                                            style="width:100px;" title="@appState.AppName Home"
+                                            alt="@appState.AppName" /><br />@appState.AppName</a>
                                     <br />
                                 </div>
                             }
@@ -92,20 +111,27 @@
                             {
                                 case "Google":
                                 case "Facebook":
-                                    <MudButton Class="signInWithButton" Variant="MudBlazor.Variant.Filled" Color="Color.Primary" OnClick="@(() => SignInWith(provider))"><img height="18" src="/images/@(provider.AuthenticationScheme.ToLower()).svg" /></MudButton>
+                                    <MudButton Class="signInWithButton" Variant="MudBlazor.Variant.Filled" Color="Color.Primary"
+                                        OnClick="@(() => SignInWith(provider))"><img height="18"
+                                            src="/images/@(provider.AuthenticationScheme.ToLower()).svg" /></MudButton>
                                     break;
                                 case "Twitter":
                                 case "Microsoft":
                                 case "Apple":
-                                    <MudButton Class="signInWithButton" Variant="MudBlazor.Variant.Filled" Color="Color.Primary" OnClick="@(() => SignInWith(provider))"><img height="18" src="/images/@(provider.AuthenticationScheme.ToLower()).svg" />&nbsp;@provider.DisplayName</MudButton>
+                                    <MudButton Class="signInWithButton" Variant="MudBlazor.Variant.Filled" Color="Color.Primary"
+                                        OnClick="@(() => SignInWith(provider))"><img height="18"
+                                            src="/images/@(provider.AuthenticationScheme.ToLower()).svg" />&nbsp;@provider.DisplayName
+                                    </MudButton>
                                     break;
                                 default:
-                                    <MudButton Class="signInWithButton" Variant="MudBlazor.Variant.Filled" Color="Color.Primary" OnClick="@(() => SignInWith(provider))">@provider.DisplayName</MudButton>
+                                    <MudButton Class="signInWithButton" Variant="MudBlazor.Variant.Filled" Color="Color.Primary"
+                                        OnClick="@(() => SignInWith(provider))">@provider.DisplayName</MudButton>
                                     break;
                             }
                         }
                     </MudCardContent>
-                </MudCard>}
+                </MudCard>
+            }
             @if (!loginViewModel.EnableLocalLogin && !loginViewModel.VisibleExternalProviders.Any())
             {
                 <MudAlert Severity="Severity.Warning">
@@ -123,18 +149,18 @@
 
     void PasswordVisibility()
     {
-            @if (isShow)
-                {
-                    isShow = false;
-                    PasswordInputIcon = Icons.Material.Filled.VisibilityOff;
-                    PasswordInput = InputType.Password;
-                }
-                else
-                {
-                    isShow = true;
-                    PasswordInputIcon = Icons.Material.Filled.Visibility;
-                    PasswordInput = InputType.Text;
-                }
+        @if (isShow)
+        {
+            isShow = false;
+            PasswordInputIcon = Icons.Material.Filled.VisibilityOff;
+            PasswordInput = InputType.Password;
         }
+        else
+        {
+            isShow = true;
+            PasswordInputIcon = Icons.Material.Filled.Visibility;
+            PasswordInput = InputType.Text;
+        }
+    }
 
 }


### PR DESCRIPTION
#477
- Sometimes it happens that the user copies accidentally a space when they copy username and password.
- Space at the end of username and password should be ignored.