### PR TITLE
Add: Tooltip for dataset configurartion page

### DIFF
--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetPreview.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/DatasetPreview.razor
@@ -4,19 +4,23 @@
 @inject IViewNotifier viewNotifier
 @inject NavigationManager NavManager
 @attribute [Authorize]
+@using Radzen
+@using Radzen.Blazor
 
 <TopSection>
     <MudBreadcrumbs Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
-<MudStack AlignItems="AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
+<MudStack AlignItems="MudBlazor.AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Material.Filled.ListAlt" />
-    <MudText Typo="Typo.h4">@_pageTitle</MudText>
+    <LabelTooltip FontSize="TextStyle.H4" Label=@_pageTitle
+        Text="Here various adjustments can be made to the dataset. For example, the use of a header row can be activated or deactivated. Rows can be ignored by changing the 'Start row' field. The separator can be defined, the encoding can be changed (default UTF-8), the datetime format can be changed and so on."
+        Position="Radzen.TooltipPosition.Bottom" URL="/help#datasetconfigure" />
 </MudStack>
 
 <MudGrid>
     <MudItem xs="12" sm="12" md="12">
-        <DatasetPreviewFull Dataset="_dataset"/>
+        <DatasetPreviewFull Dataset="_dataset" />
     </MudItem>
 </MudGrid>
 

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
@@ -137,11 +137,10 @@
         try
         {
             ApiResponseDto apiResponse = await apiClient.GetTrainings(new GetTrainingsRequestDto()
-                {
-                    Short = true,
-                    OnlyLastDay =
-                true
-                });
+            {
+                Short = true,
+                OnlyLastDay = true
+            });
 
             if (apiResponse.IsSuccessStatusCode)
             {

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Pages/Index.razor
@@ -12,15 +12,17 @@
 @using BlazorBoilerplate.Shared.Models.Account
 
 
-<div data-form-zeroStep style="border: solid none; z-index: 999; position: relative; background-color: none; border-width: 0px;"></div>
+<div data-form-zeroStep
+    style="border: solid none; z-index: 999; position: relative; background-color: none; border-width: 0px;"></div>
 <TopSection>
     <MudBreadcrumbs Style="z-index:1!important;" Items="_breadcrumbs" Class="mudbreadcrumbs"></MudBreadcrumbs>
 </TopSection>
 
 <MudStack AlignItems="MudBlazor.AlignItems.Center" Row="true" Class="mb-2" style="padding-top:50px">
     <MudIcon Size="Size.Large" Icon="@Icons.Filled.Home" />
-    <LabelTooltip FontSize="TextStyle.H4" Label=@_pageTitle Text="A dataset contains data that can be used for machine learning. Different dataset types are distinguished, e.g., tabular data, texts or images. This page lists all datasets you have uploaded so far to the OMA-ML platform. By clicking on a dataset, the respective dataset page is opened to inspect the dataset and start new trainings." Position="Radzen.TooltipPosition.Bottom"></LabelTooltip>
-
+    <LabelTooltip FontSize="TextStyle.H4" Label=@_pageTitle
+        Text="A dataset contains data that can be used for machine learning. Different dataset types are distinguished, e.g., tabular data, texts or images. This page lists all datasets you have uploaded so far to the OMA-ML platform. By clicking on a dataset, the respective dataset page is opened to inspect the dataset and start new trainings."
+        Position="Radzen.TooltipPosition.Bottom"></LabelTooltip>
 </MudStack>
 
 <MudGrid>
@@ -41,16 +43,19 @@
                     {
                         <MudGrid>
                             <MudItem xs="3" sm="3" md="3">
-                                <MudText Typo="Typo.body2">@L["My datasets {0}", _overviewInfos.TotalDatasetAmount]</MudText>
+                                <MudText Typo="Typo.body2">@L["My datasets {0}", _overviewInfos.TotalDatasetAmount]
+                                </MudText>
                             </MudItem>
                             <MudItem xs="3" sm="3" md="3">
-                                <MudText Typo="Typo.body2">@L["My trainings {0}", _overviewInfos.TotalTrainingAmount]</MudText>
+                                <MudText Typo="Typo.body2">@L["My trainings {0}", _overviewInfos.TotalTrainingAmount]
+                                </MudText>
                             </MudItem>
                             <MudItem xs="3" sm="3" md="3">
                                 <MudText Typo="Typo.body2">@L["My models {0}", _overviewInfos.TotalModelAmount]</MudText>
                             </MudItem>
                             <MudItem xs="3" sm="3" md="3">
-                                <MudText Typo="Typo.body2">@L["Executing trainings {0}", _overviewInfos.RunningTrainingAmount]</MudText>
+                                <MudText Typo="Typo.body2">@L["Executing trainings {0}",
+                                _overviewInfos.RunningTrainingAmount]</MudText>
                             </MudItem>
                         </MudGrid>
                     }
@@ -131,7 +136,12 @@
     {
         try
         {
-            ApiResponseDto apiResponse = await apiClient.GetTrainings(new GetTrainingsRequestDto() { Short = true, OnlyLastDay = true });
+            ApiResponseDto apiResponse = await apiClient.GetTrainings(new GetTrainingsRequestDto()
+                {
+                    Short = true,
+                    OnlyLastDay =
+                true
+                });
 
             if (apiResponse.IsSuccessStatusCode)
             {
@@ -187,7 +197,8 @@
 
             if (apiResponse.IsSuccessStatusCode)
             {
-                _overviewInfos = Newtonsoft.Json.JsonConvert.DeserializeObject<GetHomeOverviewInformationResponseDto>(apiResponse.Result.ToString());
+                _overviewInfos =
+                Newtonsoft.Json.JsonConvert.DeserializeObject<GetHomeOverviewInformationResponseDto>(apiResponse.Result.ToString());
             }
             else
             {

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/LabelTooltip.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/LabelTooltip.razor
@@ -1,20 +1,24 @@
 @using Radzen.Blazor
 @using Radzen
 @inject TooltipService tooltipService
+
 @if (@Icon)
 {
     <span style="display:flex">
-        <RadzenText Style="font-family:Arial, Helvetica, sans-serif; font-weight:150; " Text=@Label TextStyle=@FontSize />
-        <div style="padding-left:5pt; align-content:center; margin-top:auto; margin-bottom:auto">
-            <RadzenIcon Icon="info" IconColor="@Radzen.Colors.Black" Style="opacity:50%;" MouseEnter="@(args => ShowTooltipWithHtml(args, new TooltipOptions() { Position = @Position, Duration=5000}))" />
-        </div>
-    </span>
+    <RadzenText Style="font-family:Arial, Helvetica, sans-serif; font-weight:150; " Text=@Label TextStyle=@FontSize />
+    <div style="padding-left:5pt; align-content:center; margin-top:auto; margin-bottom:auto">
+        <RadzenIcon Icon="info" IconColor="@Radzen.Colors.Black" Style="opacity:50%;"
+            MouseEnter="@(args => ShowTooltipWithHtml(args, new TooltipOptions() { Position = @Position, Duration=5000}))" />
+    </div>
+</span>
 }
 else
 {
     <span style="display:flex">
-        <RadzenText MouseEnter="@(args => ShowTooltipWithHtml(args, new TooltipOptions() { Position = @Position, Duration=5000}))" Style="font-family:Arial, Helvetica, sans-serif; font-weight:150; " Text=@Label TextStyle=@FontSize />
-    </span>
+    <RadzenText
+        MouseEnter="@(args => ShowTooltipWithHtml(args, new TooltipOptions() { Position = @Position, Duration=5000 }))"
+        Style="font-family:Arial, Helvetica, sans-serif; font-weight:150; " Text=@Label TextStyle=@FontSize />
+</span>
 }
 
 @code {
@@ -31,15 +35,20 @@ else
     [Parameter]
     public bool Icon { get; set; } = true;
 
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
 
-    void ShowTooltipWithHtml(ElementReference elementReference, TooltipOptions options = null) => tooltipService.Open(elementReference, ds =>
-    @<div class="rz-text-wrap" style="max-width:20rem">
+    void ShowTooltipWithHtml(ElementReference elementReference, TooltipOptions options = null) =>
+        tooltipService.Open(elementReference, ds =>
+    @<div class="rz-text-wrap" style="word-wrap: break-word;max-width: 20rem;">
         @Text @if (!string.IsNullOrEmpty(URL))
     {
-        <a target="_blank" rel="noopener noreferrer" href=@URL style="color:white"><u> More...</u></a>
-}
+        @* <a target="_blank" rel="noopener noreferrer" href="@URL" class="mud-tooltip mud-tooltip-default tooltiptext"
+    style="text-decoration:underline opacity: 100% !important; color: white !important;"> More...</a> *@
+        <span> </span>
+        <a target="_blank" rel="noopener noreferrer" href="@URL"
+            style="text-decoration: underline; opacity: 100% !important; color: white !important;">More...</a>
+    }
+        @ChildContent
     </div>, options);
-
-
 }
-

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/LabelTooltip.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/LabelTooltip.razor
@@ -43,8 +43,6 @@ else
     @<div class="rz-text-wrap" style="word-wrap: break-word;max-width: 20rem;">
         @Text @if (!string.IsNullOrEmpty(URL))
     {
-        @* <a target="_blank" rel="noopener noreferrer" href="@URL" class="mud-tooltip mud-tooltip-default tooltiptext"
-    style="text-decoration:underline opacity: 100% !important; color: white !important;"> More...</a> *@
         <span> </span>
         <a target="_blank" rel="noopener noreferrer" href="@URL"
             style="text-decoration: underline; opacity: 100% !important; color: white !important;">More...</a>


### PR DESCRIPTION
#479
- User does not understand what he can do on the Dataset configuration page.
- Add the information-icon with tooltip and an appropriate explanation.
- Add href to the dataset configuration help page