### PR TITLE
Trainings and Home Pages: Refresh Page after Element Deletion 

### DIFF
--- a/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
+++ b/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
@@ -1403,6 +1403,10 @@ msgid "Start Training"
 msgstr "Start Training"
 
 msgctxt "Global"
+msgid "Create a new Training"
+msgstr "Create a new Training"
+
+msgctxt "Global"
 msgid "Dataset {0}"
 msgstr "Dataset {0}"
 
@@ -2029,3 +2033,7 @@ msgstr "Results"
 msgctxt "Global"
 msgid "Help search ..."
 msgstr "Help search ..."
+
+msgctxt "Global"
+msgid "There are no models yet because no training has been carried out."
+msgstr "There are no models yet because no training has been carried out."

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Models/Top3Models.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Models/Top3Models.razor
@@ -17,6 +17,7 @@
                             StartIcon="@Icons.Material.Filled.ReadMore"
                             Color="Color.Secondary"
                             Size="Size.Small"
+                            Disabled="@(_modelsCount == 0)"
                             Style="margin-top: 8px">@L["More"]</MudButton>
                 </ButtonTooltip>
             }
@@ -28,7 +29,7 @@
             {
                 <DataLoaderSpinner />
             }
-            else
+            else if (_modelsCount > 0)
             {
                 <MudTable Items="@_models.Models" FixedHeader="true" style="width:stretch" class="mat-elevation-z5" AllowSelection="false" Dense="true" Height="245px" CustomHeader="true">
                     <HeaderContent>
@@ -94,6 +95,10 @@
                     </RowTemplate>
                 </MudTable>
             }
+            else
+            {
+                <MudText Typo="Typo.body1" Class="text-card-content">@L["There are no models yet because no training has been carried out."]</MudText>
+            }
         </MudPaper>
     </MudCardContent>
 </MudCard>
@@ -119,6 +124,7 @@
     private GetModelsResponseDto _models;
     private List<Metric> _metrics = new List<Metric>();
     private string SelectedMetric { get; set; } = "";
+    private int _modelsCount = 0;
 
     private async Task LoadTrainings()
     {
@@ -129,6 +135,7 @@
             if (apiResponse.IsSuccessStatusCode)
             {
                 _models = Newtonsoft.Json.JsonConvert.DeserializeObject<GetModelsResponseDto>(apiResponse.Result.ToString());
+                _modelsCount = _models.Models.Count;
                 UpdateMetricsList();
                 StateHasChanged();
             }

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Trainings/NewTraining.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Trainings/NewTraining.razor
@@ -25,7 +25,7 @@
                                Variant="Variant.Filled"
                                StartIcon="@Icons.Filled.ModelTraining"
                                Color="Color.Secondary" Style="align-self:center">
-                        @L["Start Training"]
+                        @L["Create a new Training"]
                     </MudButton>
                 }
                 else
@@ -34,7 +34,7 @@
                                Variant="Variant.Filled" data-form-thirdStep
                                StartIcon="@Icons.Filled.ModelTraining"
                                Color="Color.Secondary" Style="align-self:center">
-                        @L["Start Training"]
+                        @L["Create a new Training"]
                     </MudButton>
                 }
 


### PR DESCRIPTION
**Issue**

1. Error in Language File "Global.Details"
2. If you delete a dataset or a training, the page does not refresh and the deleted one remains visible.

**Solutions**

1. Add Details to the English language file.
2. Refresh the page so that the deleted elements disappear.