### PR TITLE
Add Details to the English language and Refresh the page after  the deleted elements

### DIFF
--- a/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
+++ b/frontend/src/Server/BlazorBoilerplate.Server/Localization/en-US.po
@@ -2029,3 +2029,7 @@ msgstr "Results"
 msgctxt "Global"
 msgid "Help search ..."
 msgstr "Help search ..."
+
+msgctxt "Global"
+msgid "Details"
+msgstr "Details"

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Datasets/DatasetMenu.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Datasets/DatasetMenu.razor
@@ -7,7 +7,8 @@
 <MudMenu Icon="@Icons.Material.Filled.MoreVert">
     @if (Dataset != null)
     {
-        <MudMenuItem OnClick="@(e => { NavManager.NavigateTo("/datasets/" + Dataset.Id + "/train"); })">@L["Train"]</MudMenuItem>
+        <MudMenuItem OnClick="@(e => { NavManager.NavigateTo("/datasets/" + Dataset.Id + "/train"); })">@L["Train"]
+        </MudMenuItem>
         <MudMenuItem OnClick="@DeleteDataset">@L["Delete"]</MudMenuItem>
     }
 </MudMenu>
@@ -23,15 +24,16 @@
         try
         {
             DeleteDatasetRequestDto datasetRequest = new DeleteDatasetRequestDto()
-            {
-                DatasetId = Dataset.Id
-            };
+                {
+                    DatasetId = Dataset.Id
+                };
             ApiResponseDto apiResponse = await apiClient.DeleteDataset(datasetRequest);
 
             if (apiResponse.IsSuccessStatusCode)
             {
                 await OnDeleteCompleted.InvokeAsync();
                 viewNotifier.Show(apiResponse.Message, ViewNotifierType.Success, L["Operation Successful"]);
+                NavManager.NavigateTo(NavManager.Uri, forceLoad: true);
             }
             else
             {

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Trainings/TrainingMenu.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Trainings/TrainingMenu.razor
@@ -27,6 +27,7 @@
             {
                 await OnDeleteCompleted.InvokeAsync();
                 viewNotifier.Show(apiResponse.Message, ViewNotifierType.Success, L["Operation Successful"]);
+                NavManager.NavigateTo(NavManager.Uri, forceLoad: true);
             }
             else
             {


### PR DESCRIPTION
**Issue**

1. Error in Language File "Global.Details"
2. If you delete a dataset or a training, the page does not refresh and the deleted one remains visible.

**Solutions**

1. Add Details to the English language file.
2. Refresh the page so that the deleted elements disappear.