### PR TITLE
 clearly separation from the tables in the Datasets page

### DIFF
--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Datasets/Preview/TabularPreviewFull.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Datasets/Preview/TabularPreviewFull.razor
@@ -10,46 +10,47 @@
 }
 else
 {
-    <MudStack>
-        <MudGrid>
-            <MudItem xs="3" sm="3" md="3">
-                <MudCheckBox @bind-Checked="@UseHeader" Label="@L["Use header"]"></MudCheckBox>
-                <MudNumericField @bind-Value="@StartRow" Label="@L["Start row"]" Variant="Variant.Text" Min="1" />
-            </MudItem>
-            <MudItem xs="3" sm="3" md="3">
-                <MudSelect T="string" Label="@L["Column seperator"]" AnchorOrigin="Origin.BottomCenter" @bind-Value="@Delimiter">
-                    <MudSelectItem Value="@("comma")" >@(L["Comma \",\""])</MudSelectItem>
-                    <MudSelectItem Value="@("semicolon")" >@(L["Semicolon \";\""])</MudSelectItem>
-                    <MudSelectItem Value="@("space")">@(L["Space"])</MudSelectItem>
-                    <MudSelectItem Value="@("tab")">@(L["Tab"])</MudSelectItem>
-                </MudSelect>
-                <MudSelect T="string" Label="@L["Encoding"]" AnchorOrigin="Origin.BottomCenter" @bind-Value="@DatasetEncoding">
-                    <MudSelectItem Value="@("utf-8")" >@(L["UTF-8"])</MudSelectItem>
-                    <MudSelectItem Value="@("latin-1")" >@(L["latin-1"])</MudSelectItem>
-                    <MudSelectItem Value="@("utf-16")" >@(L["UTF-16"])</MudSelectItem>
-                    <MudSelectItem Value="@("utf-32")" >@(L["UTF-32"])</MudSelectItem>
-                </MudSelect>
-                <MudTextField Label="@L["Datetime format"]" @bind-Value="@DatetimeFormat" Variant="@Variant.Text" />
-            </MudItem>
-            <MudItem xs="3" sm="3" md="3">
-                <MudTextField Mask="@(new RegexMask(@"^.{1,1}$"))" Label="@L["Escape character"]" @bind-Value="@EscapeCharacter"  Variant="@Variant.Text" />
-                <MudTextField Mask="@(new RegexMask(@"^.{1,1}$"))" Label="@L["Decimal character"]" @bind-Value="@DecimalCharacter" Variant="@Variant.Text" />
-                <MudTextField Mask="@(new RegexMask(@"^.{0,1}$"))" Label="@L["Thousand seperator"]" @bind-Value="@ThousandsSeperator" Variant="@Variant.Text" />
-            </MudItem>
-            <MudItem xs="3" sm="3" md="3" class="text-right">
-                <ButtonTooltip Text="Save adjustments made to the dataset." Position="Placement.Left">
-                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" StartIcon="@Icons.Filled.Save" Style="margin-top: 8px" OnClick="@SaveConfiguration">@L["Save"]</MudButton>
-                </ButtonTooltip>
-            </MudItem>
-        </MudGrid>
+    <MudStack >
+        <MudPaper Elevation="5" class=" conf-table">
+           <div class="container-fluid" >
+               <MudGrid  >
+                   <MudItem xs="12" sm="6" md="4">
+                        <MudCheckBox @bind-Checked="@UseHeader" Label="@L["Use header"]"></MudCheckBox>
+                        <MudNumericField @bind-Value="@StartRow" Label="@L["Start row"]" Variant="Variant.Text" Min="1" />
+				        <MudButton Variant="Variant.Filled" Color="Color.Secondary" Style="margin-top: 20px" OnClick="@SaveConfiguration">@L["Save"]</MudButton>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="4">
+                        <MudSelect T="string" Label="@L["Column seperator"]" AnchorOrigin="Origin.BottomCenter" @bind-Value="@Delimiter">
+                            <MudSelectItem Value="@("comma")" >@(L["Comma \",\""])</MudSelectItem>
+                            <MudSelectItem Value="@("semicolon")" >@(L["Semicolon \";\""])</MudSelectItem>
+                            <MudSelectItem Value="@("space")">@(L["Space"])</MudSelectItem>
+                            <MudSelectItem Value="@("tab")">@(L["Tab"])</MudSelectItem>
+                        </MudSelect>
+                        <MudSelect T="string" Label="@L["Encoding"]" AnchorOrigin="Origin.BottomCenter" @bind-Value="@DatasetEncoding">
+                            <MudSelectItem Value="@("utf-8")" >@(L["UTF-8"])</MudSelectItem>
+                            <MudSelectItem Value="@("latin-1")" >@(L["latin-1"])</MudSelectItem>
+                            <MudSelectItem Value="@("utf-16")" >@(L["UTF-16"])</MudSelectItem>
+                            <MudSelectItem Value="@("utf-32")" >@(L["UTF-32"])</MudSelectItem>
+                            </MudSelect>
+                            <MudTextField Label="@L["Datetime format"]" @bind-Value="@DatetimeFormat" Variant="@Variant.Text" />
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="4">
+                        <MudTextField Mask="@(new RegexMask(@"^.{1,1}$"))" Label="@L["Escape character"]" @bind-Value="@EscapeCharacter"  Variant="@Variant.Text" />
+                        <MudTextField Mask="@(new RegexMask(@"^.{1,1}$"))" Label="@L["Decimal character"]" @bind-Value="@DecimalCharacter" Variant="@Variant.Text" />
+                        <MudTextField Mask="@(new RegexMask(@"^.{0,1}$"))" Label="@L["Thousand seperator"]" @bind-Value="@ThousandsSeperator" Variant="@Variant.Text" />
+                    </MudItem>
+
+                </MudGrid>
+            </div>
+        </MudPaper>
         @if (_datasetReadError == true)
         {
             <MudText Typo="Typo.body2">@L["Could not read dataset successfully, change configuration"]</MudText>
         }
         else
         {
-             <MudTable Items="@_datasetFrame.Rows" style="width:stretch" class="mat-elevation-z5" FixedHeader="true" Dense="true" CustomHeader="true">
-                <HeaderContent>
+             <MudTable Items="@_datasetFrame.Rows" Elevation="5" style="width:stretch " class="table-bordered mat-elevation-z5  " FixedHeader="true" Dense="true" CustomHeader="true">
+                <HeaderContent >
                     <MudTHeadRow>
                         <MudTh></MudTh>
                         @foreach (var item in _datasetFrame.Columns)

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/wwwroot/css/site.css
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/wwwroot/css/site.css
@@ -9,9 +9,9 @@
     width: 312px;
 }
 
-    .job-status ul {
-        flex: 1;
-    }
+.job-status ul {
+    flex: 1;
+}
 
 .dropzone {
     padding: 30px;
@@ -38,9 +38,9 @@
     width: 250px;
 }
 
-    .draggable:active {
-        cursor: grabbing;
-    }
+.draggable:active {
+    cursor: grabbing;
+}
 
 .dragging {
     cursor: grabbing;
@@ -57,18 +57,22 @@
     font-weight: bold;
 }
 
-    .last-updated small {
-        text-transform: uppercase;
-        color: #c4cbd4;
-        font-size: 11px;
-    }
+.last-updated small {
+    text-transform: uppercase;
+    color: #c4cbd4;
+    font-size: 11px;
+}
 
-h1, h2, h3 {
+h1,
+h2,
+h3 {
     color: var(--mud-palette-primary-darken);
 }
+
 p {
     margin-bottom: 12px;
 }
+
 a {
     color: var(--mud-palette-primary-lighten);
 }
@@ -92,3 +96,32 @@ a {
     font-size: clamp(0.7rem, -0.875rem + 2.4vw, 1rem);
 }
 
+.container-fluid {
+    padding: 10px 25px 50px 20px;
+    border-radius: 5px;
+}
+
+.conf-table {
+    margin-bottom: 15px;
+    height: 200px;
+
+}
+
+.table-bordered {
+    border-collapse: collapse;
+    border-radius: 5px;
+}
+
+.table-bordered th,
+.table-bordered td {
+    border: none;
+    /* Removes all internal borders */
+}
+
+.table-bordered th,
+.table-bordered td {
+    border-top: 1px solid lightgrey;
+    /* Top border for cells */
+    border-bottom: 0, 5px solid lightgrey;
+    /* Bottom border for cells */
+}


### PR DESCRIPTION
**Issue**

- [ ] The layout of the page does not fit at all. This confuses the user.

 

**Improvement**

- [ ] The input fields should be clearly separated from the table. It is best to place them in a separate tile. There should then be sufficient white space between this tile and the table below.