### PR TITLE
fixed XAI dashboard button clickability

### DIFF
--- a/controller/managers/general/ModelManager.py
+++ b/controller/managers/general/ModelManager.py
@@ -70,6 +70,11 @@ class ModelManager:
             model_info.runtime_profile = model_runtime_profile
 
             model_info.status_messages[:] =  model["status_messages"]
+
+            if not model.get("dashboard_path"):  # Returns None if key is missing
+                model_info.dashboard_status = "inactive"
+            else:
+                model_info.dashboard_status = "active"
             #model_info.explanation = json.dumps(model["explanation"])
 
             if not "carbon_footprint" in model:

--- a/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Models/Explanation/ModelExplanationShort.razor
+++ b/frontend/src/Shared/Modules/BlazorBoilerplate.Theme.MudBlazor.Demo/Shared/Components/Models/Explanation/ModelExplanationShort.razor
@@ -76,7 +76,7 @@
                         {
                             <div class="container">
                             <ButtonTooltip Text="Opens the dashboard for analyzing this ML model (Explainable AI)." Position="Placement.Top">
-                                <MudButton Disabled="IsModelBlacklisted"
+                                <MudButton Disabled="ModelEmpty"
                                            Variant="MudBlazor.Variant.Filled"
                                            StartIcon="@Icons.Material.Outlined.Analytics"
                                            Color="Color.Secondary"
@@ -130,10 +130,7 @@
             StateHasChanged();
         }
     }
-    // TODO blacklist needs to be filled out with Model that dont generate Dashboard
-   // private List<string> blacklistedModels = new List<string> { "Autogluon", "FLAML", "LAMA" , "Autokeras", "H2O Automl"};
-    private List<string> blacklistedModels = new List<string> { };
-    private bool IsModelBlacklisted => blacklistedModels.Contains(AutoMlSolutionID);
+    private bool ModelEmpty = true;
 
     private async Task LoadModelExplanation()
     {
@@ -160,6 +157,9 @@
                     Status = "finished" // Change this value for testing different scenarios: "dashboard_failed", "db_error", "finished"
                 };
 
+            if(_model.Model.DashboardStatus != "inactive"){
+                ModelEmpty=false;
+            }
             // Uncomment and use actual API call for real implementation
             /*
             GetModelExplanationRequestDto modelRequest = new GetModelExplanationRequestDto()


### PR DESCRIPTION
Added new changes from main branch and fixed the XAI Issue.
fixed The "Dashboard" should only be clickable when an actual dashboard is available https://github.com/hochschule-darmstadt/MetaAutoML/issues/540
Solution:
Set a default value to dashboard_status and made Check in ExplanationRazorShort to see if dashboard exists.

Out of Scope:
Dashboard loading times